### PR TITLE
updated WebArchive.sol

### DIFF
--- a/blockchain/contracts/WebArchive.sol
+++ b/blockchain/contracts/WebArchive.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.19;
 
 contract WebArchive {
-    address owner;
+    address public owner;
 
     // map[userAddress][hash] = timeStamp
-    mapping(address => mapping(bytes32 => uint)) archivedItemsMap;
+    mapping(address => mapping(bytes32 => uint)) internal archivedItemsMap;
 
     event ArchiveCreated(
         address indexed user,
@@ -13,11 +13,16 @@ contract WebArchive {
         uint256 timestamp
     );
 
+    error AlreadyArchived();
+
     constructor() {
         owner = msg.sender;
     }
 
     function setArchive(bytes32 _itemHash) public {
+        if (archivedItemsMap[msg.sender][_itemHash] != 0)
+            revert AlreadyArchived();
+
         archivedItemsMap[msg.sender][_itemHash] = block.timestamp;
 
         emit ArchiveCreated(msg.sender, _itemHash, block.timestamp);
@@ -25,5 +30,12 @@ contract WebArchive {
 
     function verifyHash(address user, bytes32 hash) public view returns (bool) {
         return archivedItemsMap[user][hash] != 0;
+    }
+
+    function getArchiveTimestamp(
+        address user,
+        bytes32 hash
+    ) public view returns (uint) {
+        return archivedItemsMap[user][hash];
     }
 }


### PR DESCRIPTION
added a `require()` to `setArchive()` to prevent overwriting timestamps and a view function to read timestamps of hashes